### PR TITLE
Allow newer versions of sensu-plugin dependency

### DIFF
--- a/sensu-plugins-network-interface.gemspec
+++ b/sensu-plugins-network-interface.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsNetworkInterface::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin',   '1.2.0'
+  s.add_runtime_dependency 'sensu-plugin',   '>= 1.2.0'
 end


### PR DESCRIPTION
sensu-plugin v1.2 is 1year old
sensu-plugin v2.0 is now out

Partially tested with sensu-plugin 2.0.0 (not tested all options & cases)